### PR TITLE
feat: keep translation text when switching languages

### DIFF
--- a/app/src/main/java/com/bnyro/translate/ui/screens/TranslationPage.kt
+++ b/app/src/main/java/com/bnyro/translate/ui/screens/TranslationPage.kt
@@ -154,6 +154,7 @@ fun TranslationPage(
                             val temp = viewModel.sourceLanguage
                             viewModel.sourceLanguage = viewModel.targetLanguage
                             viewModel.targetLanguage = temp
+                            viewModel.insertedText = viewModel.translation.translatedText
                             viewModel.translateNow()
                         }
                     ) {


### PR DESCRIPTION
When a user presses the 'swap languages' button, the translated text should be brought over to the input field, as it is relevant to that language. 

Before using the TranslateYou app, I had utilized this feature in Google Translate as a quick first check for translation accuracy. For example, if I translated a sentence into one language, hit the swap button and the English sentence was completely different, I knew I probably shouldn't use that translation.

I only added one line of code for this to work on my device, in the onClick function on the translate button, however I don't know the codebase very well, so let me know if there are any issues with directly assigning the input text like this. 

Thanks for the great app!