### PR TITLE
Removed translation of app_name (Except Malayalam)

### DIFF
--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -5,7 +5,6 @@
     <string name="api_key">API açar</string>
     <string name="auto">Avtomatik</string>
     <string name="instance">Nümunə</string>
-    <string name="app_name">Translate You</string>
     <string name="okay">Oldu</string>
     <string name="cancel">Ləğv et</string>
     <string name="enter_text">Mətn daxil et</string>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">Translate You</string>
     <!-- Dialog -->
     <string name="okay">D\'accord</string>
     <string name="cancel">Annuler</string>

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">Translate You</string>
     <!-- Dialog -->
     <string name="okay">אישור</string>
     <string name="cancel">ביטול</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -12,7 +12,6 @@
     <string name="license">Licenza</string>
     <string name="theme_auto">Sistema</string>
     <string name="server_error">Errore durante la comunicazione con il server.</string>
-    <string name="app_name">Traduttore You</string>
     <string name="history_summary">Tieni traccia degli ultimi testi tradotti</string>
     <string name="okay">Ok</string>
     <string name="cancel">Annulla</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name" translatable="false">Translate You</string>
     <!-- Dialog -->
     <string name="okay">Ok</string>
     <string name="cancel">Anuluj</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name" translatable="false">Translate You</string>
     <!-- Dialog -->
     <string name="okay">У реду</string>
     <string name="cancel">Откажи</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">Translate You</string>
     <string name="cancel">İptal</string>
     <string name="okay">Tamam</string>
     <string name="enter_text">Metin girin</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name" translatable="false">Translate You</string>
     <!-- Dialog -->
     <string name="okay">确定</string>
     <string name="cancel">取消</string>


### PR DESCRIPTION
But in https://github.com/you-apps/TranslateYou/blob/master/app/src/main/res/values-ml/strings.xml, there is a real translation, not a copy of the original string, what to do with this think for yourself