### PR TITLE
ci: fix that no artifacts are uploaded

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,4 +34,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: app
-          path: app/build/outputs/apk/debug/*.apk
+          path: app/build/outputs/apk/libre/debug/*.apk


### PR DESCRIPTION
```
No files were found with the provided path: app/build/outputs/apk/debug/*.apk. No artifacts will be uploaded.
```

```
~/TranslateYou$ ./gradlew assembleDebug
~/TranslateYou$ ls app/build/outputs/apk/libre/debug/
app-libre-debug.apk  output-metadata.json
```
