### PR TITLE
Update LTEngine.kt

### DIFF
--- a/app/src/main/java/com/bnyro/translate/api/lt/LTEngine.kt
+++ b/app/src/main/java/com/bnyro/translate/api/lt/LTEngine.kt
@@ -25,7 +25,7 @@ import com.bnyro.translate.util.TranslationEngine
 
 class LTEngine : TranslationEngine(
     name = "LibreTranslate",
-    defaultUrl = "https://translate.terraprint.co/",
+    defaultUrl = "https://translate.flossboxin.org.in/",
     urlModifiable = true,
     apiKeyState = ApiKeyState.OPTIONAL,
     autoLanguageCode = "auto"


### PR DESCRIPTION
Updated the LT default URL, as the terraprint one is no longer hosted. Provided with my instance.