### PR TITLE
fix(kagi): set model to standard instead of null by default

### DIFF
--- a/app/src/main/java/com/bnyro/translate/api/kagi/KagiEngine.kt
+++ b/app/src/main/java/com/bnyro/translate/api/kagi/KagiEngine.kt
@@ -68,7 +68,7 @@ class KagiEngine : TranslationEngine(
             sourceLang = sourceOrAuto(source),
             targetLang = target,
             skipDefinition = !fetchDefinitions,
-            model = if (useBestModel) "best" else null
+            model = if (useBestModel) "best" else "standard"
         )
 
         val response = api.translate(

--- a/app/src/main/java/com/bnyro/translate/api/kagi/obj/KagiTranslationRequest.kt
+++ b/app/src/main/java/com/bnyro/translate/api/kagi/obj/KagiTranslationRequest.kt
@@ -26,5 +26,5 @@ data class KagiTranslationRequest(
     @SerialName("source_lang") val sourceLang: String,
     @SerialName("target_lang") val targetLang: String,
     @SerialName("skip_definition") val skipDefinition: Boolean = false,
-    val model: String? = null
+    val model: String = "standard" // Default to "standard", can be overridden to "best"
 ) 


### PR DESCRIPTION
closes #520, we implemented some stricter validation of field on our side - and a `null` model is no longer accepted.
It either needs to be undefined (not null), or set to a valid value. 